### PR TITLE
Display obfuscated email and password consistantly

### DIFF
--- a/Gw2 Launchbuddy/MainWindow.xaml
+++ b/Gw2 Launchbuddy/MainWindow.xaml
@@ -172,7 +172,7 @@
                             <ListView.View>
                                 <GridView>
                                     <GridViewColumn Header="Nickname" Width="150" DisplayMemberBinding="{Binding Nick}" />
-                                    <GridViewColumn Header="Email" Width="200" DisplayMemberBinding="{Binding Email}" />
+                                    <GridViewColumn Header="Email" Width="200" DisplayMemberBinding="{Binding DisplayEmail}" />
                                     <GridViewColumn Header="Password" Width="150" DisplayMemberBinding="{Binding DisplayPW}" />
                                     <GridViewColumn Header="Created at" Width="150" DisplayMemberBinding="{Binding Time}" />
 

--- a/Gw2 Launchbuddy/MainWindow.xaml.cs
+++ b/Gw2 Launchbuddy/MainWindow.xaml.cs
@@ -78,23 +78,9 @@ namespace Gw2_Launchbuddy
         public class Account
         {
             public string Email { get; set; }
+            public string DisplayEmail { get { return "*****@*****.***"; } }
             public string Password { get; set; }
-            public string DisplayPW
-            {
-                get
-                {
-                    string stars = "";
-                    foreach (char ch in Password.ToCharArray())
-                    {
-                        stars += "*";
-                    }
-                    return stars;
-                }
-                set
-                {
-                    DisplayPW = value;
-                }
-            }
+            public string DisplayPW { get { return "********"; } }
             public DateTime Time { get; set; }
             public string Nick { get; set; }
         }


### PR DESCRIPTION
Use `*****@*****.***` for email display and `********` for password display consistantly so as not to display emails or allow for guessing of lengths of passwords on the account screen.

Resolves issue #6.