### PR TITLE
Autologin E-Mail Label

### DIFF
--- a/Gw2 Launchbuddy/MainWindow.xaml.cs
+++ b/Gw2 Launchbuddy/MainWindow.xaml.cs
@@ -1160,7 +1160,7 @@ namespace Gw2_Launchbuddy
             if (((ListView)sender).SelectedItems.Count != 0 && ((ListView)sender).SelectedItems.Count <= 1)
             {
                 var selectedItems = (dynamic)((ListView)sender).SelectedItems;
-                cb_login.Content = "Use Autologin : " + selectedItems[0].Email;
+                cb_login.Content = "Use Autologin : " + selectedItems[0].Nickname;
                 Globals.selected_accs[0].Email = selectedItems[0].Email;
                 Globals.selected_accs[0].Password = selectedItems[0].Password;
                 bt_shortcut.IsEnabled = true;

--- a/Gw2 Launchbuddy/MainWindow.xaml.cs
+++ b/Gw2 Launchbuddy/MainWindow.xaml.cs
@@ -1160,7 +1160,7 @@ namespace Gw2_Launchbuddy
             if (((ListView)sender).SelectedItems.Count != 0 && ((ListView)sender).SelectedItems.Count <= 1)
             {
                 var selectedItems = (dynamic)((ListView)sender).SelectedItems;
-                cb_login.Content = "Use Autologin : " + selectedItems[0].Nickname;
+                cb_login.Content = "Use Autologin : " + selectedItems[0].Nick;
                 Globals.selected_accs[0].Email = selectedItems[0].Email;
                 Globals.selected_accs[0].Password = selectedItems[0].Password;
                 bt_shortcut.IsEnabled = true;


### PR DESCRIPTION
The Autologin stated the full email adress, while it is censored in the list below. Changed to display the chosen Nickname instead.