### PR TITLE
Addon/Priority Changes 

### DIFF
--- a/Gw2 Launchbuddy/App.config
+++ b/Gw2 Launchbuddy/App.config
@@ -10,11 +10,8 @@
   </startup>
   <userSettings>
     <Gw2_Launchbuddy.Properties.Settings>
-      <setting name="use_reshade" serializeAs="String">
+      <setting name="use_priority" serializeAs="String">
         <value>False</value>
-      </setting>
-      <setting name="reshadepath" serializeAs="String">
-        <value />
       </setting>
       <setting name="use_autologin" serializeAs="String">
         <value>False</value>

--- a/Gw2 Launchbuddy/Globals.cs
+++ b/Gw2 Launchbuddy/Globals.cs
@@ -12,7 +12,7 @@ namespace Gw2_Launchbuddy
         public static ObservableCollection<AccountClient> LinkedAccs = new ObservableCollection<AccountClient>(); //Should nto be needed?
 
         //public static List<Account> selected_accs = new List<Account>();
-        public static string unlockerpath, version_api; //Should be split out into respective managers
+        public static string version_api; //Should be split out into respective managers
 
         public static Server selected_authsv = new Server(); //Should be removed/Unneeded with Manager
         public static Server selected_assetsv = new Server(); //Should be removed/Unneeded with Manager

--- a/Gw2 Launchbuddy/LaunchManager.cs
+++ b/Gw2 Launchbuddy/LaunchManager.cs
@@ -101,19 +101,9 @@ namespace Gw2_Launchbuddy
                     }
                 }
 
-                if (Properties.Settings.Default.use_reshade)
+                if (Properties.Settings.Default.use_priority)
                 {
-                    try
-                    {
-                        ProcessStartInfo unlockerpro = new ProcessStartInfo();
-                        unlockerpro.FileName = Globals.unlockerpath;
-                        unlockerpro.WorkingDirectory = Path.GetDirectoryName(Globals.unlockerpath);
-                        Process.Start(unlockerpro);
-                    }
-                    catch (Exception err)
-                    {
-                        MessageBox.Show("Could not launch ReshadeUnlocker. Invalid path?\n" + err.Message);
-                    }
+                    gw2Client.SetPriority(Properties.Settings.Default.priority);
                 }
             }
             catch (Exception err)

--- a/Gw2 Launchbuddy/LaunchManager.cs
+++ b/Gw2 Launchbuddy/LaunchManager.cs
@@ -49,10 +49,10 @@ namespace Gw2_Launchbuddy
 
             GFXManager.RestoreDefault();
 
-            //Launching AddOns
+            //Launching Singleton AddOns
             try
             {
-                AddOnManager.LaunchAll();
+                AddOnManager.SingletonAddon();
             }
             catch (Exception err)
             {
@@ -74,6 +74,16 @@ namespace Gw2_Launchbuddy
                 {
                     Account undefacc = new Account("Acc Nr" + Globals.LinkedAccs.Count, null, null);
                     Globals.LinkedAccs.Add(new AccountClient(undefacc, gw2Client));
+                }
+
+                //Launching multilauch addons before.
+                try
+                {
+                    AddOnManager.LaunchAllBefore();
+                }
+                catch (Exception err)
+                {
+                    MessageBox.Show("One or more multilaunch before AddOns could not be launched.\n" + err.Message);
                 }
 
                 try
@@ -104,6 +114,16 @@ namespace Gw2_Launchbuddy
                 if (Properties.Settings.Default.use_priority)
                 {
                     gw2Client.SetPriority(Properties.Settings.Default.priority);
+                }
+
+                //Launching multilauch addons after.
+                try
+                {
+                    AddOnManager.LaunchAllAfter();
+                }
+                catch (Exception err)
+                {
+                    MessageBox.Show("One or more multilaunch after AddOns could not be launched.\n" + err.Message);
                 }
             }
             catch (Exception err)

--- a/Gw2 Launchbuddy/MainWindow.xaml
+++ b/Gw2 Launchbuddy/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:local="clr-namespace:Gw2_Launchbuddy"
         xmlns:System="clr-namespace:System;assembly=mscorlib" xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero" x:Class="Gw2_Launchbuddy.MainWindow"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        xmlns:Diagnostics="clr-namespace:System.Diagnostics;assembly=System"
         x:Name="myWindow"
         WindowStyle="None"
         ShowInTaskbar="true"
@@ -564,8 +565,17 @@
                             <ColumnDefinition Width="50*" />
                             <ColumnDefinition Width="50*" />
                         </Grid.ColumnDefinitions>
-                        <CheckBox x:Name="cb_reshade" Content="Use Reshade Unlocker" Checked="cb_reshade_Checked" Unchecked="cb_reshade_Unchecked" FontSize="16" FontWeight="Bold" IsEnabled="False"  VerticalAlignment="Center" HorizontalAlignment="Left" Grid.Row="3" Margin="5,0,0,0" />
-                        <Button x:Name="bt_reshadepath" Content="Set ReshadeUnlocker Path" Click="bt_reshadepath_Click" Grid.Column="1" Grid.Row="3" Margin="5,0,0,0" />
+                        <CheckBox x:Name="cb_priority" Content="Use Priority Unlocker" Checked="cb_priority_Checked" Unchecked="cb_priority_Unchecked" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Left" Grid.Row="3" Margin="5,0,0,0" />
+                        <ComboBox x:Name="priority_type" Grid.Column="2" Grid.Row="3" SelectedValue="Normal" SelectionChanged="priority_type_SelectionChanged" Margin="5,5,5,0">
+                            <ComboBox.DataContext>
+                                <Diagnostics:ProcessPriorityClass>Normal</Diagnostics:ProcessPriorityClass>
+                            </ComboBox.DataContext>
+                            <Diagnostics:ProcessPriorityClass>Idle</Diagnostics:ProcessPriorityClass>
+                            <Diagnostics:ProcessPriorityClass>BelowNormal</Diagnostics:ProcessPriorityClass>
+                            <Diagnostics:ProcessPriorityClass>Normal</Diagnostics:ProcessPriorityClass>
+                            <Diagnostics:ProcessPriorityClass>AboveNormal</Diagnostics:ProcessPriorityClass>
+                            <Diagnostics:ProcessPriorityClass>High</Diagnostics:ProcessPriorityClass>
+                        </ComboBox>
                         <Label x:Name="lab_AddOnManager" Content="AddOn Manager:" HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" />
 
                         <ListView x:Name="lv_AddOns" Grid.Row="1" Grid.ColumnSpan="2">

--- a/Gw2 Launchbuddy/MainWindow.xaml
+++ b/Gw2 Launchbuddy/MainWindow.xaml
@@ -556,16 +556,79 @@
                     <Grid Grid.Row="4">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="30" />
-                            <RowDefinition Height="150*" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="30" />
+                            <RowDefinition Height="140*" />
+                            <RowDefinition Height="20*" />
+                            <RowDefinition Height="10*" />
                         </Grid.RowDefinitions>
 
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="50*" />
-                            <ColumnDefinition Width="50*" />
+                            <ColumnDefinition Width="119*" />
+                            <ColumnDefinition Width="228*" />
+                            <ColumnDefinition Width="347*" />
                         </Grid.ColumnDefinitions>
-                        <CheckBox x:Name="cb_priority" Content="Use Priority Unlocker" Checked="cb_priority_Checked" Unchecked="cb_priority_Unchecked" FontSize="16" FontWeight="Bold" VerticalAlignment="Center" HorizontalAlignment="Left" Grid.Row="3" Margin="5,0,0,0" />
+
+                        <Label x:Name="lab_AddOnManager" Content="AddOn Manager:" HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" Grid.ColumnSpan="2" />
+
+                        <ListView x:Name="lv_AddOns" Grid.Row="1" Grid.ColumnSpan="3">
+                            <ListView.View>
+                                <GridView ColumnHeaderStringFormat="" AllowsColumnReorder="False">
+                                    <GridViewColumn>
+                                        <GridViewColumnHeader Tag="Enabled" Click="listview_auth_Click" Content="Enable" Padding="10,0" />
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <CheckBox x:Name="cb_enable" Click="cb_enable_Click" IsChecked="{Binding IsEnabled}" />
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
+                                    <GridViewColumn  HeaderStringFormat="" DisplayMemberBinding="{Binding Name}">
+                                        <GridViewColumnHeader Tag="Name" Click="listview_auth_Click" Content="Name" Padding="10,0" />
+                                    </GridViewColumn>
+                                    <GridViewColumn HeaderStringFormat="" DisplayMemberBinding="{Binding args}">
+                                        <GridViewColumnHeader Tag="args" Click="listview_auth_Click" Content="Parameters" Padding="10,0" />
+                                    </GridViewColumn>
+                                    <GridViewColumn HeaderStringFormat="" DisplayMemberBinding="{Binding IsMultilaunch}">
+                                        <GridViewColumnHeader Tag="IsMultilaunch" Click="listview_auth_Click" Content="Multilaunch" Padding="10,0" />
+                                    </GridViewColumn>
+                                    <GridViewColumn HeaderStringFormat="" DisplayMemberBinding="{Binding IsMultibefore}">
+                                        <GridViewColumnHeader Tag="IsMultibefore" Click="listview_auth_Click" Content="Before" Padding="10,0" />
+                                    </GridViewColumn>
+                                    <GridViewColumn HeaderStringFormat="" DisplayMemberBinding="{Binding IsSinglelaunch}">
+                                        <GridViewColumnHeader Tag="IsSinglelaunch" Click="listview_auth_Click" Content="Single" Padding="10,0" />
+                                    </GridViewColumn>
+                                    <GridViewColumn HeaderStringFormat="" DisplayMemberBinding="{Binding Path}">
+                                        <GridViewColumnHeader Tag="Path" Click="listview_auth_Click" Content="Path" Padding="10,0" />
+                                    </GridViewColumn>
+                                </GridView>
+                            </ListView.View>
+                        </ListView>
+
+                        <Grid x:Name="grid_Addons_Add" Grid.Row="2" Grid.ColumnSpan="3" Margin="0,10,-1,0" Width="695">
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                                <RowDefinition Height="24" />
+                            </Grid.RowDefinitions>
+
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="140*" />
+                                <ColumnDefinition Width="140*" />
+                                <ColumnDefinition Width="95*" />
+                                <ColumnDefinition Width="100*" />
+                                <ColumnDefinition Width="100*" />
+                                <ColumnDefinition Width="100*" />
+                            </Grid.ColumnDefinitions>
+                            <Label Content="Name:" Grid.ColumnSpan="2"  FontSize="13" />
+                            <TextBox x:Name="tb_AddonName" Grid.Row="1" Margin="5,0" />
+                            <Label Content="Parameters:" Grid.Column="1" FontSize="13" />
+                            <TextBox x:Name="tb_AddonArgs" Grid.Column="1" Grid.Row="1" Margin="5,0" />
+                            <CheckBox x:Name="cb_AddonMultiLaunch" Grid.Row="1" Grid.Column="2" Content="Multilaunch" Margin="5,0" VerticalContentAlignment="Center" Checked="cb_AddonMulti_Checked" Unchecked="cb_AddonMulti_Unchecked" />
+                            <CheckBox x:Name="cb_AddonMultiBefore" Grid.Row="1" Grid.Column="3" Content="Before" Margin="5,0" VerticalContentAlignment="Center" IsEnabled="False" />
+                            <CheckBox x:Name="cb_AddonSingle" Grid.Row="1" Grid.Column="4" Content="Singlelaunch" Margin="5,0"  VerticalContentAlignment="Center" Unchecked="cb_AddonSingle_Unchecked" Checked="cb_AddonSingle_Checked" />
+                            <Button x:Name="bt_AddAddon" Grid.Column="3" Content="Add" Click="bt_AddAddon_Click" Margin="5,0" />
+                            <Button x:Name="bt_RemAddon" Grid.Column="5" Content="Remove" Click="bt_RemAddon_Click" Margin="5,0" />
+                            <Button x:Name="bt_EditAddon" Grid.Column="4" Content="Edit" Click="bt_EditAddon_Click" Margin="5,0" />
+                        </Grid>
+
+                        <CheckBox x:Name="cb_priority" Grid.Row="3" Content="Use Priority Unlocker" Checked="cb_priority_Checked" Unchecked="cb_priority_Unchecked" FontSize="16" FontWeight="Bold" Margin="5,5,5,0" VerticalContentAlignment="Center" Grid.ColumnSpan="2" />
                         <ComboBox x:Name="priority_type" Grid.Column="2" Grid.Row="3" SelectedValue="Normal" SelectionChanged="priority_type_SelectionChanged" Margin="5,5,5,0">
                             <ComboBox.DataContext>
                                 <Diagnostics:ProcessPriorityClass>Normal</Diagnostics:ProcessPriorityClass>
@@ -576,39 +639,6 @@
                             <Diagnostics:ProcessPriorityClass>AboveNormal</Diagnostics:ProcessPriorityClass>
                             <Diagnostics:ProcessPriorityClass>High</Diagnostics:ProcessPriorityClass>
                         </ComboBox>
-                        <Label x:Name="lab_AddOnManager" Content="AddOn Manager:" HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" />
-
-                        <ListView x:Name="lv_AddOns" Grid.Row="1" Grid.ColumnSpan="2">
-                            <ListView.View>
-                                <GridView ColumnHeaderStringFormat="" AllowsColumnReorder="False">
-                                    <GridViewColumn  HeaderStringFormat="" Width="150" DisplayMemberBinding="{Binding Name}">
-                                        <GridViewColumnHeader Tag="Name" Click="listview_auth_Click" Content="Name" />
-                                    </GridViewColumn>
-                                    <GridViewColumn HeaderStringFormat="" Width="200" DisplayMemberBinding="{Binding args}">
-                                        <GridViewColumnHeader Tag="args" Click="listview_auth_Click" Content="Parameters" />
-                                    </GridViewColumn>
-                                    <GridViewColumn HeaderStringFormat="" Width="70" DisplayMemberBinding="{Binding IsMultilaunch}">
-                                        <GridViewColumnHeader Tag="IsMultilaunch" Click="listview_auth_Click" Content="Multilaunch" />
-                                    </GridViewColumn>
-                                    <GridViewColumn Width="80" DisplayMemberBinding="{Binding IsLbAddon}">
-                                        <GridViewColumnHeader Tag="IsLbAddon" Click="listview_auth_Click" Content="Start with LB" />
-                                    </GridViewColumn>
-                                    <GridViewColumn  DisplayMemberBinding="{Binding Path}">
-                                        <GridViewColumnHeader Tag="Path" Click="listview_auth_Click" Content="Path" />
-                                    </GridViewColumn>
-                                </GridView>
-                            </ListView.View>
-                        </ListView>
-                        <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.ColumnSpan="2" Margin="0,5">
-                            <Label Content="Name:" />
-                            <TextBox x:Name="tb_AddonName" Width="100" />
-                            <Label Content="Parameters" />
-                            <TextBox x:Name="tb_AddonArgs" Width="100" />
-                            <CheckBox x:Name="cb_AddonMultilaunch" Content="Multilaunch"  VerticalAlignment="Center" Margin="5,0" />
-                            <CheckBox x:Name="cb_AddonOnLB" Content="Start with LB" VerticalAlignment="Center" Margin="5,0" />
-                            <Button x:Name="bt_AddAddon" Content="Add" HorizontalAlignment="Right" VerticalAlignment="Center" Width="75" Margin="5,0" Click="bt_AddAddon_Click" />
-                            <Button x:Name="bt_RemAddon" Content="Remove" HorizontalAlignment="Right" VerticalAlignment="Center" Width="75" Margin="5,0" Click="bt_RemAddon_Click" />
-                        </StackPanel>
                     </Grid>
                 </TabItem>
                 <TabItem Header="Cinema Mode">

--- a/Gw2 Launchbuddy/MainWindow.xaml.cs
+++ b/Gw2 Launchbuddy/MainWindow.xaml.cs
@@ -623,23 +623,12 @@ namespace Gw2_Launchbuddy
 
         private void LoadConfig()
         {
-            //Checking if path for reshade unlocker is saved
-
-            if (Properties.Settings.Default.reshadepath != "")
-            {
-                try
-                {
-                    Globals.unlockerpath = Properties.Settings.Default.reshadepath;
-                }
-                catch { }
-                cb_reshade.IsEnabled = true;
-            }
-
             try
             {
-                if (Properties.Settings.Default.use_reshade && cb_reshade.IsEnabled == true) cb_reshade.IsChecked = true;
+                // Checking if saved priority is different then normal and if its enabled.
+                if (Properties.Settings.Default.priority != 0) priority_type.SelectedValue = Properties.Settings.Default.priority;
+                if (Properties.Settings.Default.use_priority == true) cb_priority.IsChecked = true;
                 if (Properties.Settings.Default.use_autologin == true) cb_login.IsChecked = true;
-
                 //if (Properties.Settings.Default.selected_acc != 0) listview_acc.SelectedIndex = Cinema_Accountlist.SelectedIndex = Properties.Settings.Default.selected_acc;
             }
             catch (Exception err)
@@ -682,8 +671,6 @@ namespace Gw2_Launchbuddy
             // Read the xml file
             try
             {
-                if (Properties.Settings.Default.use_reshade) cb_reshade.IsChecked = true;
-
                 StreamReader stream = new System.IO.StreamReader(Globals.ClientXmlpath);
                 XmlTextReader reader = null;
                 reader = new XmlTextReader(stream);
@@ -922,21 +909,9 @@ namespace Gw2_Launchbuddy
                 shortcut.IconLocation = Assembly.GetExecutingAssembly().Location;
                 shortcut.Description = "Created with Gw2 Launchbuddy, © TheCheatsrichter";
 
-                if (cb_reshade.IsChecked == true)
-                {
-                    // Using commandline to launch both exe files from the link file
-                    // EXAMPLE: cmd.exe /c start "" "C:\Program Files (x86)\Guild Wars 2\ReshadeUnlocker" && start "" "C:\Program Files (x86)\Guild Wars 2\Gw2"
-                    shortcut.Arguments = " /c start \"\" \"" + Globals.unlockerpath + "\" && start \"\" \"" + ClientManager.ClientInfo.InstallPath + ClientManager.ClientInfo.Executable + "\" " + arguments;
-                    MessageBox.Show(shortcut.Arguments);
-                    shortcut.TargetPath = "cmd.exe"; // win will automatically extend this to the cmd path
-                    shortcut.Save();
-                }
-                else
-                {
-                    shortcut.Arguments = arguments;
-                    shortcut.TargetPath = targetFileLocation;
-                    shortcut.Save();
-                }
+                shortcut.Arguments = arguments;
+                shortcut.TargetPath = targetFileLocation;
+                shortcut.Save();
 
                 string dynamicinfo = "";
                 foreach (string arg in arguments.Split(' '))
@@ -944,7 +919,7 @@ namespace Gw2_Launchbuddy
                     dynamicinfo += arg + "\n\t\t";
                 }
 
-                System.Windows.MessageBox.Show("Custom Launcher created at : " + ClientManager.ClientInfo.InstallPath + "\nUse ReshadeUnlocker: " + cb_reshade.IsChecked.ToString() + "\nUsed arguments:" + dynamicinfo);
+                System.Windows.MessageBox.Show("Custom Launcher created at : " + ClientManager.ClientInfo.InstallPath + "\nUsed arguments:" + dynamicinfo);
             }
             catch (Exception err)
             {
@@ -1097,7 +1072,8 @@ namespace Gw2_Launchbuddy
         {
             Properties.Settings.Default.instance_win_X = Globals.Appmanager.Left;
             Properties.Settings.Default.instance_win_Y = Globals.Appmanager.Top;
-            Properties.Settings.Default.use_reshade = (bool)cb_reshade.IsChecked;
+            Properties.Settings.Default.use_priority = (bool)cb_priority.IsChecked;
+            Properties.Settings.Default.priority = (ProcessPriorityClass)priority_type.SelectedValue;
             Properties.Settings.Default.Save();
             AccountManager.ImportExport.SaveAccountInfo();
             SaveAddons();
@@ -1136,31 +1112,6 @@ namespace Gw2_Launchbuddy
             Globals.selected_assetsv.Port = tb_assetsport.Text;
         }
 
-        private void cb_reshade_Unchecked(object sender, RoutedEventArgs e)
-        {
-        }
-
-        private void bt_reshadepath_Click(object sender, RoutedEventArgs e)
-        {
-            System.Windows.Forms.OpenFileDialog filedialog = new System.Windows.Forms.OpenFileDialog();
-            filedialog.DefaultExt = "exe";
-            filedialog.Multiselect = false;
-            filedialog.Filter = "Exe Files(*.exe) | *.exe";
-            filedialog.ShowDialog();
-
-            if (filedialog.FileName == "" || !filedialog.FileName.EndsWith(".exe"))
-            {
-                MessageBox.Show("Invalid .exe file selected!");
-                cb_reshade.IsChecked = false;
-            }
-            else
-            {
-                Globals.unlockerpath = filedialog.FileName;
-                cb_reshade.IsEnabled = true;
-                Gw2_Launchbuddy.Properties.Settings.Default.reshadepath = Globals.unlockerpath;
-            }
-        }
-
         private void exp_server_Collapsed(object sender, RoutedEventArgs e)
         {
             //ServerUI.Height = new GridLength(30);
@@ -1179,34 +1130,6 @@ namespace Gw2_Launchbuddy
             view.SortDescriptions.Add(new SortDescription("Ping", ListSortDirection.Ascending));
             CollectionView sview = (CollectionView)CollectionViewSource.GetDefaultView(listview_assets.ItemsSource);
             sview.SortDescriptions.Add(new SortDescription("Ping", ListSortDirection.Ascending));
-        }
-
-        private void cb_reshade_Checked(object sender, RoutedEventArgs e)
-        {
-            if (!System.IO.File.Exists(Globals.unlockerpath))
-            {
-                cb_reshade.IsChecked = false;
-                MessageBox.Show("ReShadeUnlocker.exe not found at :\n" + ClientManager.ClientInfo.InstallPath + "\nPlease select the ReshadeUnlocker.exe manually!");
-                System.Windows.Forms.OpenFileDialog filedialog = new System.Windows.Forms.OpenFileDialog();
-                filedialog.DefaultExt = "exe";
-                filedialog.Multiselect = false;
-                filedialog.Filter = "Exe Files(*.exe) | *.exe";
-                filedialog.ShowDialog();
-
-                if (filedialog.FileName == "" || !filedialog.FileName.EndsWith(".exe"))
-                {
-                    MessageBox.Show("Invalid .exe file selected!");
-                }
-                else
-                {
-                    Globals.unlockerpath = filedialog.FileName;
-                    try
-                    {
-                        Gw2_Launchbuddy.Properties.Settings.Default.reshadepath = Globals.unlockerpath;
-                    }
-                    catch { }
-                }
-            }
         }
 
         private void SortByColumn(ListView list, object sender)
@@ -1928,6 +1851,21 @@ namespace Gw2_Launchbuddy
         {
             Properties.Settings.Default.notifylbupdate = (bool)cb_lbupdatescheck.IsChecked;
             Properties.Settings.Default.Save();
+        }
+
+        private void cb_priority_Unchecked(object sender, RoutedEventArgs e)
+        {
+            Properties.Settings.Default.use_priority = false;
+        }
+
+        private void cb_priority_Checked(object sender, RoutedEventArgs e)
+        {
+            Properties.Settings.Default.use_priority = true;
+        }
+
+        private void priority_type_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            Properties.Settings.Default.priority = (ProcessPriorityClass)priority_type.SelectedItem;
         }
 
         private void cb_useinstancegui_Click(object sender, RoutedEventArgs e)

--- a/Gw2 Launchbuddy/MainWindow.xaml.cs
+++ b/Gw2 Launchbuddy/MainWindow.xaml.cs
@@ -107,7 +107,7 @@ namespace Gw2_Launchbuddy
             cinema_setup();
             LoadAddons();
             SettingsTabSetup();
-            AddOnManager.LaunchLbAddons();
+            AddOnManager.SingletonAddon();
             if (Properties.Settings.Default.notifylbupdate)
             {
                 Thread checklbver = new Thread(checklbversion);
@@ -1077,6 +1077,7 @@ namespace Gw2_Launchbuddy
             Properties.Settings.Default.Save();
             AccountManager.ImportExport.SaveAccountInfo();
             SaveAddons();
+            AddOnManager.CloseAll();
             Environment.Exit(Environment.ExitCode);
         }
 
@@ -1194,22 +1195,6 @@ namespace Gw2_Launchbuddy
         {
             myWindow.WindowState = WindowState.Minimized;
             myWindow.Opacity = 0;
-        }
-
-        private void bt_AddAddon_Click(object sender, RoutedEventArgs e)
-        {
-            string[] args = Regex.Matches(tb_AddonArgs.Text, "-\\w* ?(\".*\")?").Cast<Match>().Select(m => m.Value).ToArray();
-            AddOnManager.Add(tb_AddonName.Text, args, (bool)cb_AddonMultilaunch.IsChecked, (bool)cb_AddonOnLB.IsChecked);
-            lv_AddOns.ItemsSource = AddOnManager.AddOns;
-        }
-
-        private void bt_RemAddon_Click(object sender, RoutedEventArgs e)
-        {
-            AddOn item = lv_AddOns.SelectedItem as AddOn;
-            if (item != null)
-            {
-                AddOnManager.Remove(item.Name);
-            }
         }
 
         private void bt_cinema_setimagefolder_Click(object sender, RoutedEventArgs e)
@@ -1866,6 +1851,76 @@ namespace Gw2_Launchbuddy
         private void priority_type_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             Properties.Settings.Default.priority = (ProcessPriorityClass)priority_type.SelectedItem;
+        }
+
+        private void cb_enable_Click(object sender, RoutedEventArgs e)
+        {
+            AddOn addon = (sender as CheckBox).DataContext as AddOn;
+            addon.IsEnabled = (bool)(sender as CheckBox).IsChecked;
+        }
+
+        private void bt_EditAddon_Click(object sender, RoutedEventArgs e)
+        {
+            AddOn selectedaddon = lv_AddOns.SelectedItem as AddOn;
+            if (selectedaddon != null)
+            {
+                cb_AddonMultiBefore.IsChecked = selectedaddon.IsMultibefore;
+                cb_AddonMultiLaunch.IsChecked = selectedaddon.IsMultilaunch;
+                cb_AddonSingle.IsChecked = selectedaddon.IsSinglelaunch;
+                tb_AddonName.Text = selectedaddon.Name;
+                tb_AddonArgs.Text = selectedaddon.args;
+            }
+            else
+            {
+                MessageBox.Show("Please select addon!");
+            }
+
+            AddOn item = lv_AddOns.SelectedItem as AddOn;
+            AddOnManager.Remove(item.Name);
+        }
+
+        private void bt_AddAddon_Click(object sender, RoutedEventArgs e)
+        {
+            string[] args = Regex.Matches(tb_AddonArgs.Text, "--\\w* ?(\".*\")?|-\\w* ?(\".*\")?").Cast<Match>().Select(m => m.Value).ToArray(); //New Regex --\w* ?(\".*\")?|-\w* ?(\".*\")?
+            AddOnManager.Add(tb_AddonName.Text, args, (bool)cb_AddonMultiLaunch.IsChecked, (bool)cb_AddonMultiBefore.IsChecked, (bool)cb_AddonSingle.IsChecked, true);
+            tb_AddonName.Text = "";
+            tb_AddonArgs.Text = "";
+            cb_AddonMultiLaunch.IsChecked = false;
+            cb_AddonMultiBefore.IsChecked = false;
+            cb_AddonSingle.IsChecked = false;
+            lv_AddOns.ItemsSource = AddOnManager.AddOns;
+        }
+
+        private void bt_RemAddon_Click(object sender, RoutedEventArgs e)
+        {
+            AddOn item = lv_AddOns.SelectedItem as AddOn;
+            if (item != null)
+            {
+                AddOnManager.Remove(item.Name);
+            }
+        }
+
+        private void cb_AddonMulti_Checked(object sender, RoutedEventArgs e)
+        {
+            cb_AddonMultiBefore.IsEnabled = true;
+            cb_AddonSingle.IsEnabled = false;
+        }
+
+        private void cb_AddonMulti_Unchecked(object sender, RoutedEventArgs e)
+        {
+            cb_AddonMultiBefore.IsEnabled = false;
+            cb_AddonMultiBefore.IsChecked = false;
+            cb_AddonSingle.IsEnabled = true;
+        }
+
+        private void cb_AddonSingle_Unchecked(object sender, RoutedEventArgs e)
+        {
+            cb_AddonMultiLaunch.IsEnabled = true;
+        }
+
+        private void cb_AddonSingle_Checked(object sender, RoutedEventArgs e)
+        {
+            cb_AddonMultiLaunch.IsEnabled = false;
         }
 
         private void cb_useinstancegui_Click(object sender, RoutedEventArgs e)

--- a/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
@@ -170,6 +170,11 @@ namespace Gw2_Launchbuddy.ObjectManagers
             Process.WaitForExit();
         }
 
+        public void SetPriority(ProcessPriorityClass priority)
+        {
+            Process.PriorityClass = priority;
+        }
+
         private void ClientProcess_Exited(object sender, EventArgs e)
         {
             Process.Exited -= ClientProcess_Exited;

--- a/Gw2 Launchbuddy/Properties/Settings.Designer.cs
+++ b/Gw2 Launchbuddy/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Gw2_Launchbuddy.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -26,24 +26,23 @@ namespace Gw2_Launchbuddy.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool use_reshade {
+        public bool use_priority {
             get {
-                return ((bool)(this["use_reshade"]));
+                return ((bool)(this["use_priority"]));
             }
             set {
-                this["use_reshade"] = value;
+                this["use_priority"] = value;
             }
         }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string reshadepath {
+        public global::System.Diagnostics.ProcessPriorityClass priority {
             get {
-                return ((string)(this["reshadepath"]));
+                return ((global::System.Diagnostics.ProcessPriorityClass)(this["priority"]));
             }
             set {
-                this["reshadepath"] = value;
+                this["priority"] = value;
             }
         }
         

--- a/Gw2 Launchbuddy/Properties/Settings.settings
+++ b/Gw2 Launchbuddy/Properties/Settings.settings
@@ -2,10 +2,10 @@
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="Gw2_Launchbuddy.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
-    <Setting Name="use_reshade" Type="System.Boolean" Scope="User">
+    <Setting Name="use_priority" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="reshadepath" Type="System.String" Scope="User">
+    <Setting Name="priority" Type="System.Diagnostics.ProcessPriorityClass" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="use_autologin" Type="System.Boolean" Scope="User">


### PR DESCRIPTION
I removed the Reshade  unlocker option since Reshade is open-source, and there is [GW2Hook](https://github.com/04348/Gw2Hook) .
And replaced it with a priority change option. This option allows to set the procces priority of the gw2 process this has increased my gw2 frame-rate drastically. However increasing the priority negatively impacts other processes running in the background.
Added some features too the addon tab as well as reorganizing some of the weird grid placements of the buttons and check boxes. 
- Edit button for easy editing of addons
- Enable checkbox per addon so you can enable/disable addons without deleting them. 
- Multilaunch and singlelaunch. Multilaunch will start the addon per instance of gw2 with the option too do so before or after the process is started. Singlelaunch will work as a singleton and there will only be one instance of the addon.
- Added the ability too use the --run argument for the use with [Xenos](https://github.com/DarthTon/Xenos) which allows for wraping/proxy of dll's. 