### PR TITLE
launch in bin64 when using account info

### DIFF
--- a/Gw2 Launchbuddy/ApplicationManager.cs
+++ b/Gw2 Launchbuddy/ApplicationManager.cs
@@ -116,17 +116,18 @@ namespace Gw2_Launchbuddy
                 ProcessStartInfo gw2proinfo = new ProcessStartInfo();
                 gw2proinfo.FileName = Globals.exepath + Globals.exename;
                 gw2proinfo.Arguments = Globals.args.Print(accnr);
-                gw2proinfo.WorkingDirectory = Globals.exepath;
                 Process gw2pro = new Process { StartInfo = gw2proinfo };
                 if (accnr != null)
                 {
                     Globals.LinkedAccs.Add(new ProAccBinding(gw2pro, Globals.selected_accs[(int)accnr]));
                     GFXManager.UseGFX(Globals.selected_accs[(int)accnr].Configpath);
+                    gw2proinfo.WorkingDirectory = Globals.exepath + "bin64";
                 }
                 else
                 {
                     MainWindow.Account undefacc = new MainWindow.Account { Email = "-", Nick = "Acc Nr" + Globals.LinkedAccs.Count };
                     Globals.LinkedAccs.Add(new ProAccBinding(gw2pro, undefacc));
+                    gw2proinfo.WorkingDirectory = Globals.exepath;
                 }
 
                 try


### PR DESCRIPTION
When launching with account info, we use nopatchui in order to launch the game directly without showing the window. Unfortunately, nopatchui causes the game to not change directory into bin64 before fully launching. Fix this by launching the game directly in bin64 using the working directory option.

It might be worth actually testing whether or not our arguments have nopatchui instead of relying on account name, but I haven't found a good way to do that yet.