### PR TITLE
Single launch account .dat file switching mockup

### DIFF
--- a/Gw2 Launchbuddy/App.config
+++ b/Gw2 Launchbuddy/App.config
@@ -79,6 +79,9 @@
       <setting name="mainwin_size_y" serializeAs="String">
         <value>-1</value>
       </setting>
+	  <setting name="datlaunching" serializeAs="String">
+        <value>False</value>
+      </setting>
     </Gw2_Launchbuddy.Properties.Settings>
   </userSettings>
   <runtime>

--- a/Gw2 Launchbuddy/MainWindow.xaml
+++ b/Gw2 Launchbuddy/MainWindow.xaml
@@ -340,6 +340,7 @@
                                     <Button x:Name="bt_installpath" DockPanel.Dock="Right" ToolTip="Set your gamefolder path if it isn't &#x0a; determined correctly by launchbuddy" Content="Set Directory" Click="bt_installpath_Click" Grid.Row="0" Grid.Column="1" VerticalAlignment="Bottom"  BorderThickness="1" Width="100" HorizontalAlignment="Right" Margin="0,0,0,5"/>
                                     <Label x:Name="lab_path" Content="Install Path:" Grid.Column="1" Grid.Row="1"/>
                                 </DockPanel>
+                                <CheckBox x:Name="datlaunchingcheckbox" Content="Dat Launching" Click="CheckBox_Click" Checked="datlaunchingcheckbox_Checked"/>
 
                             </StackPanel>
                             <Grid Grid.Column="2" Grid.Row="1" HorizontalAlignment="Right">
@@ -355,7 +356,7 @@
                         </Grid>
                         <Separator Margin="5" DockPanel.Dock="Top"/>
                         <Label Content="Accounts:" Style="{StaticResource H1}" DockPanel.Dock="Top"/>
-                        <ListView x:Name="lv_accs" DataContext="{Binding Path=Account}" SelectionChanged="lv_accs_SelectionChanged" SelectionMode="Multiple">
+                        <ListView x:Name="lv_accs" DataContext="{Binding Path=Account}" SelectionChanged="lv_accs_SelectionChanged" SelectionMode="Multiple" MouseDoubleClick="lv_accs_MouseDoubleClick">
                             <ListView.ItemContainerStyle>
                                 <Style TargetType="ListViewItem">
                                     <Setter Property="HorizontalContentAlignment" Value="Stretch"/>

--- a/Gw2 Launchbuddy/MainWindow.xaml.cs
+++ b/Gw2 Launchbuddy/MainWindow.xaml.cs
@@ -154,6 +154,7 @@ namespace Gw2_Launchbuddy
         {
             cb_lbupdatescheck.IsChecked = Properties.Settings.Default.notifylbupdate;
             cb_useinstancegui.IsChecked = Properties.Settings.Default.useinstancegui;
+            datlaunchingcheckbox.IsChecked = Properties.Settings.Default.datlaunching;
         }
 
         private void DonatePopup()
@@ -584,8 +585,17 @@ namespace Gw2_Launchbuddy
             }
             else
             {
-                if (EnviromentManager.LBUseClientGUI) EnviromentManager.LBInstanceGUI.Show();
-                AccountManager.LaunchAccounts();
+                //if (EnviromentManager.LBUseClientGUI) EnviromentManager.LBInstanceGUI.Show(); // Disabled because the setting won't work for me
+                if (Properties.Settings.Default.datlaunching)
+                {
+                    if (Process.GetProcessesByName(Path.GetFileNameWithoutExtension(EnviromentManager.GwClientExePath)).Count() < 1) { AccountManager.LaunchAccounts(); }
+                    else { MessageBox.Show("You can't have more than one account launched at a time with datlaunching enabled."); }
+                }
+                else
+                {
+                    AccountManager.LaunchAccounts();
+                }
+
                 if (addonflag)
                 {
                     addonflag = false;
@@ -1543,6 +1553,31 @@ namespace Gw2_Launchbuddy
             lv_AddOns.ItemsSource = AddOnManager.addOnCollection;
         }
         #endregion DELETE ON 1.9
+
+        private void CheckBox_Click(object sender, RoutedEventArgs e)
+        {
+            Properties.Settings.Default.datlaunching = (bool)datlaunchingcheckbox.IsChecked;
+            Properties.Settings.Default.Save();
+        }
+
+        private void datlaunchingcheckbox_Checked(object sender, RoutedEventArgs e)
+        {
+            Properties.Settings.Default.datlaunching = (bool)(sender as CheckBox).IsChecked;
+
+            if ((bool)(sender as CheckBox).IsChecked)
+            {
+                lv_accs.SelectionMode = SelectionMode.Single;
+            }
+            else
+            {
+                lv_accs.SelectionMode = SelectionMode.Multiple;
+            }
+        }
+
+        private void lv_accs_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            bt_launch_Click(sender, e);
+        }
 
         private void sl_logoendpos_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {

--- a/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
@@ -350,7 +350,6 @@ namespace Gw2_Launchbuddy.ObjectManagers
 
                 try
                 {
-                    Debug.WriteLine("DeltraCodeLauncing: " + Properties.Settings.Default.datlaunching.ToString());
                     string SymLinkingPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Guild Wars 2\";
                     string target = Path.Combine(SymLinkingPath, "Local.dat");
                     string source = Path.Combine(SymLinkingPath, "Local-" + account.Nickname + ".dat");
@@ -559,7 +558,7 @@ namespace Gw2_Launchbuddy.ObjectManagers
 
                         case var expression when (Status < ClientStatus.Created):
 							if (!Properties.Settings.Default.datlaunching) { Process.Start(); }
-							else { if (File.Exists(@"C:\Users\Harrison\AppData\Roaming\Guild Wars 2\local.dat")) { Process.Start(); } } // Need to add some sort of error check to see if a .dat file is actually linked here, this is buggy.
+							else { if (File.Exists(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Guild Wars 2\local.dat")) { Process.Start(); } } // Need to add some sort of error check to see if a .dat file is actually linked here, this is buggy.
                             Suspend();
                             Status = ClientStatus.Created;
                             break;

--- a/Gw2 Launchbuddy/ObjectManagers/CrashAnalyzer.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/CrashAnalyzer.cs
@@ -218,7 +218,7 @@ namespace Gw2_Launchbuddy
             }
             catch (Exception e)
             {
-                System.Windows.Forms.MessageBox.Show("Could not open Crashlog!\n"+ e.Message);
+               //System.Windows.Forms.MessageBox.Show("Could not open Crashlog!\n"+ e.Message); // Why bother telling the user their crash log doesn't exist?
             }
         }
     }

--- a/Gw2 Launchbuddy/Properties/Settings.Designer.cs
+++ b/Gw2 Launchbuddy/Properties/Settings.Designer.cs
@@ -298,5 +298,17 @@ namespace Gw2_Launchbuddy.Properties {
                 this["mainwin_size_y"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool datlaunching {
+            get {
+                return ((bool)(this["datlaunching"]));
+            }
+            set {
+                this["datlaunching"] = value;
+            }
+        }
     }
 }

--- a/Gw2 Launchbuddy/Properties/Settings.settings
+++ b/Gw2 Launchbuddy/Properties/Settings.settings
@@ -71,5 +71,8 @@
     <Setting Name="mainwin_size_y" Type="System.Double" Scope="User">
       <Value Profile="(Default)">-1</Value>
     </Setting>
+    <Setting Name="datlaunching" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
A mockup of .dat file symlinking for single accounts. Some things are disabled or bugged, but I figured you wouldn't mind having a somewhat functioning version for launching single accounts. No idea how you are going to be able to do this with multiple accounts. How does sandboxie work with GW2?

----
Changes...
----
The process priority setter checks if null, but not if normal (default). No point in changing normal to normal. This probably is still the wrong code, I haven't done any programming since my last commit.

Added checkbox and setting for datlaunching, this should probably be moved to the settings page, not the main launcher tab.

Added double click to launch an account. Only works like that when datlaunchingcheckbox has been checked.

Removed the line notifying user that their crash log doesn't exist.

Messing with the mutex is useless if launching only a single account. It now checks for that.

----
ToDo...
----
Need to add some sort of error check to see if a .dat file is actually linked when launching, this is buggy without.

Stop the launcher asking for a relaunch when launching with the -image parameter.