### PR TITLE
catch permission errors when grabbing process start time

### DIFF
--- a/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
@@ -109,7 +109,16 @@ namespace Gw2_Launchbuddy.ObjectManagers
                     }
                     if (pro != null)
                     {
-                        if (pro.StartTime.ToString() == line.Split(',')[3])
+                        String processStartTime;
+                        try
+                        {
+                            processStartTime = pro.StartTime.ToString();
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+                        if (processStartTime == line.Split(',')[3])
                         {
                             Client.ClientStatus status = (Client.ClientStatus)Int32.Parse(line.Split(',')[1]);
                             acc.Client.SetProcess(pro,status);


### PR DESCRIPTION
Some processes may not allow accessing the start time. If such a process
is running when Gw2 Launch Buddy is started, it can prevent the
application from starting properly.

Catch errors when trying to grab the process start time and skip that
process if we can't access it.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>