### PR TITLE
fix localdat gw2build id for DEBUG builds

### DIFF
--- a/Gw2 Launchbuddy/Modifiers/LocalDatManager.cs
+++ b/Gw2 Launchbuddy/Modifiers/LocalDatManager.cs
@@ -235,9 +235,7 @@ namespace Gw2_Launchbuddy.Modifiers
                     MessageBox.Show($"INFO: Loginfile for {file.Name} did not change between the updates. If this error persist pls reenter Login data.");
                 }
 
-#if !DEBUG
                 file.gw2build = Api.ClientBuild;
-#endif
                 ToDefault();
             }
 


### PR DESCRIPTION
If Gw2 Launchbuddy is built using the DEBUG configuration, it will not
properly update the local.dat Gw2 build ids. This unnecessarily causes
the program to continuously try to update the login files every time it
loads an account.

Fix this by removing the !DEBUG check around the id update code.

It does not make sense for the program to behave significantly
differently when in DEBUG mode.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>