### PR TITLE
Fix update checking when check for updates is disabled

### DIFF
--- a/Gw2 Launchbuddy/Helpers/Versionswitcher.cs
+++ b/Gw2 Launchbuddy/Helpers/Versionswitcher.cs
@@ -17,6 +17,11 @@ namespace Gw2_Launchbuddy
         private static string Repo_User, Repo_Name;
         public static ObservableCollection<Release> Releaselist = new ObservableCollection<Release>();
 
+        public static bool ShouldCheckForUpdate()
+        {
+            return LBConfiguration.Config.notifylbupdate;
+        }
+
         public static void CheckForUpdate()
         {
             if (Releaselist.Count == 0)

--- a/Gw2 Launchbuddy/MainWindow.xaml.cs
+++ b/Gw2 Launchbuddy/MainWindow.xaml.cs
@@ -115,7 +115,7 @@ namespace Gw2_Launchbuddy
             lv_accs.ItemsSource = AccountManager.Accounts;
             lv_accssettings.ItemsSource = AccountManager.Accounts;
             SettingsTabSetup();
-            if (LBConfiguration.Config.notifylbupdate)
+            if (VersionSwitcher.ShouldCheckForUpdate())
             {
                 Thread checklbver = new Thread(checklbversion);
                 checklbver.Start();

--- a/Gw2 Launchbuddy/ObjectManagers/EnviromentManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/EnviromentManager.cs
@@ -89,7 +89,6 @@ namespace Gw2_Launchbuddy.ObjectManagers
             //Updater Network Protocol
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             VersionSwitcher.DeleteUpdater();
-            VersionSwitcher.CheckForUpdate();
 
             //Account Import Export
             AccountManager.ImportAccounts();


### PR DESCRIPTION
Fixed forced update checking by removing CheckForUpdate() from Init() in EnvironmentManager since we already check for updates in MainWindow's Init().
Also replaced raw usage of "LBConfiguration.Config.notifylbupdate" in MainWindow to instead use the newly created ShouldCheckForUpdate() in VersionSwitcher to make it clearer what it's actually doing.

From testing, this fixes the issue and doesn't seem to cause any other issues to arise from the removal of CheckForUpdate() from Init() in EnvironmentManager.

Closes #198 