### PR TITLE
Add new -dx9 and -dx11 commands, minor changes to command loading.

### DIFF
--- a/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
@@ -132,6 +132,19 @@ namespace Gw2_Launchbuddy.ObjectManagers
 
                     foreach(Account acc in (ObservableCollection<Account>)deserializer.Deserialize(xmlInputStream))
                     {
+                        Arguments tempArguments = new Arguments();
+                        foreach (var argmt in tempArguments)
+                        {
+                            try
+                            {
+                                argmt.IsActive = acc.Settings.Arguments.First(a => a.Flag == argmt.Flag).IsActive;
+                            }
+                            catch (Exception e)
+                            {
+                                // Pass this. Probably use FirstOrDefault here.
+                            }
+                        }
+                        acc.Settings.Arguments = tempArguments;
                         //Do not add accs as they get added on Init!
                     }
                     xmlInputStream.Close();

--- a/Gw2 Launchbuddy/ObjectManagers/Arguments.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/Arguments.cs
@@ -27,6 +27,8 @@ namespace Gw2_Launchbuddy.ObjectManagers
             Add(new Argument("-windowed", "Forces Guild Wars 2 to run in windowed mode. In game, you can switch to windowed mode by pressing Alt + Enter or clicking the window icon in the upper right corner.", false));
             Add(new Argument("-umbra gpu", "Forces the use of umbra's GPU accelerated culling. In most cases, using this results in higher cpu usage and lower gpu usage decreasing the frame-rate.", false));
             Add(new Argument("-maploadinfo", "Shows diagnostic information during map loads, including load percentages and elapsed time.", false));
+            Add(new Argument("-dx9", "Forces the game to run using the DirectX 9 renderer.", false));
+            Add(new Argument("-dx11", "Forces the game to run using the beta DirectX 11 renderer.", false));
         }
 
         private Arguments() { }


### PR DESCRIPTION
Arguments are stored entirely within the Accs.xml file, including their descriptions, with means that adding new Arguments is cumbersome. To fix this (so that the new -dx9 and -dx11 arguments could be added), I made a change to the way arguments are loaded from those files. Instead of using the entire collection straight from the XML file, instead the arguments are matched up with a "master list" of arguments maintained in the Arguments.cs file and that collection is used instead. This way, when commands are added/removed, the Accs.xml is updated to match.