### PR TITLE
Fixed AccountID in AccountSettings.

### DIFF
--- a/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
@@ -65,9 +65,10 @@ namespace Gw2_Launchbuddy.ObjectManagers
                 gw2build = acc.Settings.Loginfile.Gw2Build,
                 Valid = acc.Settings.Loginfile.Valid,
             };
+            newacc.Settings.AccountID = newacc.ID;
 
             File.Copy(acc.Settings.Loginfile.Path, newacc.Settings.Loginfile.Path);
-            
+
             SaveAccounts();
             ImportAccounts();
         }
@@ -317,7 +318,7 @@ namespace Gw2_Launchbuddy.ObjectManagers
                 if (GFXFile == null) GFXFile = GFXManager.LoadFile(EnviromentManager.GwClientXmlPath);
             }
             catch { MessageBox.Show("LB could not find any default graphic settings file. Launch gw2 at least once to fix this issue."); }
-            
+
             if (DLLs == null) DLLs = new ObservableCollection<string>();
             if (AccHotkeys == null) AccHotkeys = new ObservableCollection<AccountHotkey>();
             if (RelaunchesMax == null) RelaunchesMax = 0;


### PR DESCRIPTION
Just a little fix.
AccountSettings.AccountID was the ID of the "old" Account instead of the new ID of cloned Account. This caused problems for BlishValid/TacoValid -> Icons not visible when the account is running. Or showing when the "wrong" account (with old ID) is running.

Now the new ID gets written in AccountSettings on cloning the account.