### PR TITLE
Check 4 hours for active accounts; remove double delay at <13

### DIFF
--- a/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
@@ -646,14 +646,8 @@ namespace Gw2_Launchbuddy.ObjectManagers
 				    break;
 			}
 
-            //Determine if the waiting time has already completed
-
-            bool recent_login = AccountManager.Accounts.Count(x => x.Settings.AccountInformation.HadLoginInPastMinutes(timetowait / 60000) == true) > 0;
-
-            if (recent_login) {
-                Action loginwait = () => { Thread.Sleep(timetowait); };
-                Helpers.BlockerInfo.Run("Delaying Login", $"Launchbuddy is currently delaying the login for {timetowait / 1000} sec(s). This is a safety measure to avoid triggering GW2 DDOS protection. Press cancel to skip.", loginwait);
-            }
+            Action loginwait = () => { Thread.Sleep(timetowait); };
+            Helpers.BlockerInfo.Run("Delaying Login", $"Launchbuddy is currently delaying the login for {timetowait / 1000} sec(s). This is a safety measure to avoid triggering GW2 DDOS protection. Press cancel to skip.", loginwait);
 
             Loginfiller.PressLoginButton(Account);
         }

--- a/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
@@ -619,25 +619,25 @@ namespace Gw2_Launchbuddy.ObjectManagers
 
             int timetowait = 0;
 
-            //Get all accounts which where active in the last 120 minutes
+            //Get all accounts that were active in the last 4 hours
 
-            int active_accounts = AccountManager.Accounts.Count(x => x.Settings.AccountInformation.HadLoginInPastMinutes(120) == true);
+            int active_accounts = AccountManager.Accounts.Count(x => x.Settings.AccountInformation.HadLoginInPastMinutes(240) == true);
 
             switch (active_accounts)
 			{	
-				case int _ when _ >= 36:
+				case int _ when active_accounts >= 36:
 				    timetowait = 120 * 1000;
 				    break;
 					
-				case int _ when _ >= 31:
+				case int _ when active_accounts >= 31:
 				    timetowait = 60 * 1000;
 				    break;
 					
-				case int _ when _ >= 21:
+				case int _ when active_accounts >= 21:
 				    timetowait = 40 * 1000;
 				    break;
 					
-				case int _ when _ >= 13:
+				case int _ when active_accounts >= 13:
 				    timetowait = 20 * 1000;
 				    break;
 					
@@ -645,10 +645,15 @@ namespace Gw2_Launchbuddy.ObjectManagers
 				    timetowait = 1800 + (active_accounts * active_accounts * 80);
 				    break;
 			}
-			
-            Action loginwait = () => { Thread.Sleep(timetowait); };
 
-            Helpers.BlockerInfo.Run("Delaying Login",$"Launchbuddy is currently delaying the login for {timetowait / 1000} sec(s). This is a safety measure to avoid triggering GW2 DDOS protection. Press cancel to skip.",loginwait);
+            //Determine if the waiting time has already completed
+
+            bool recent_login = AccountManager.Accounts.Count(x => x.Settings.AccountInformation.HadLoginInPastMinutes(timetowait / 60000) == true) > 0;
+
+            if (recent_login) {
+                Action loginwait = () => { Thread.Sleep(timetowait); };
+                Helpers.BlockerInfo.Run("Delaying Login", $"Launchbuddy is currently delaying the login for {timetowait / 1000} sec(s). This is a safety measure to avoid triggering GW2 DDOS protection. Press cancel to skip.", loginwait);
+            }
 
             Loginfiller.PressLoginButton(Account);
         }

--- a/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
@@ -624,27 +624,27 @@ namespace Gw2_Launchbuddy.ObjectManagers
             int active_accounts = AccountManager.Accounts.Count(x => x.Settings.AccountInformation.HadLoginInPastMinutes(240) == true);
 
             switch (active_accounts)
-			{	
-				case int _ when active_accounts >= 36:
-				    timetowait = 120 * 1000;
-				    break;
-					
-				case int _ when active_accounts >= 31:
-				    timetowait = 60 * 1000;
-				    break;
-					
-				case int _ when active_accounts >= 21:
-				    timetowait = 40 * 1000;
-				    break;
-					
-				case int _ when active_accounts >= 13:
-				    timetowait = 20 * 1000;
-				    break;
-					
-				default:
-				    timetowait = 1800 + (active_accounts * active_accounts * 80);
-				    break;
-			}
+            {
+                case int _ when active_accounts >= 36:
+                    timetowait = 120 * 1000;
+                    break;
+
+                case int _ when active_accounts >= 31:
+                    timetowait = 60 * 1000;
+                    break;
+
+                case int _ when active_accounts >= 21:
+                    timetowait = 40 * 1000;
+                    break;
+
+                case int _ when active_accounts >= 13:
+                    timetowait = 20 * 1000;
+                    break;
+
+                default:
+                    timetowait = 1800 + (active_accounts * active_accounts * 80);
+                    break;
+            }
 
             Action loginwait = () => { Thread.Sleep(timetowait); };
             Helpers.BlockerInfo.Run("Delaying Login", $"Launchbuddy is currently delaying the login for {timetowait / 1000} sec(s). This is a safety measure to avoid triggering GW2 DDOS protection. Press cancel to skip.", loginwait);

--- a/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/ClientManager.cs
@@ -619,47 +619,36 @@ namespace Gw2_Launchbuddy.ObjectManagers
 
             int timetowait = 0;
 
-            //Get all accounts which where active in the last 30 minutes
+            //Get all accounts which where active in the last 120 minutes
 
-            int active_accounts = AccountManager.Accounts.Count(x => x.Settings.AccountInformation.HadLoginInPastMinutes(30) == true);
+            int active_accounts = AccountManager.Accounts.Count(x => x.Settings.AccountInformation.HadLoginInPastMinutes(120) == true);
 
-
-            if (active_accounts <= 12)
-            {
-                timetowait = 1800 + (active_accounts * active_accounts * 80);
-                Thread.Sleep(timetowait);
-            } else
-            {
-                if(active_accounts >= 36)
-                {
-                    timetowait = 120 *1000;
-                }
-                else
-                {
-                    if (active_accounts >= 31)
-                    {
-                        timetowait = 60 * 1000;
-                    }
-                    else
-                    {
-                        if (active_accounts >= 21)
-                        {
-                            timetowait = 40 * 1000;
-                        }
-                        else
-                        {
-                            if (active_accounts >= 13)
-                            {
-                                timetowait = 20 * 1000;
-                            }
-                        }
-                    }
-                }
-            }
-
+            switch (active_accounts)
+			{	
+				case int _ when _ >= 36:
+				    timetowait = 120 * 1000;
+				    break;
+					
+				case int _ when _ >= 31:
+				    timetowait = 60 * 1000;
+				    break;
+					
+				case int _ when _ >= 21:
+				    timetowait = 40 * 1000;
+				    break;
+					
+				case int _ when _ >= 13:
+				    timetowait = 20 * 1000;
+				    break;
+					
+				default:
+				    timetowait = 1800 + (active_accounts * active_accounts * 80);
+				    break;
+			}
+			
             Action loginwait = () => { Thread.Sleep(timetowait); };
 
-            Helpers.BlockerInfo.Run("Delaying Login",$"Launchbuddy currently delays the login for {timetowait / 1000} sec(s). This is a safety messurement to not trigger GW2 DDOS protection. Press cancel to skip",loginwait);
+            Helpers.BlockerInfo.Run("Delaying Login",$"Launchbuddy is currently delaying the login for {timetowait / 1000} sec(s). This is a safety measure to avoid triggering GW2 DDOS protection. Press cancel to skip.",loginwait);
 
             Loginfiller.PressLoginButton(Account);
         }


### PR DESCRIPTION
The total minimum time delay for 39 accounts is 23.59 minutes. By account 42, this is about 30 minutes; not including time between delays or if the launch process is stopped for a few minutes and started again. The logic that checks for active accounts only considers logins in the last 30 minutes, but Guild Wars 2 takes hours to stop considering login attempts in its DDOS protection calculation. After 30 minutes, LB will start *decreasing* the delay instead of increasing it.

I've set Launchbuddy's check to 4 hours, but we probably need more research on when login attempts drop off of the game's radar.

There are still some flaws here:

- The game treats multiple successful logins to the same account as multiple logins for its calculation, not as one single login. So starting and stopping the same account multiple times (e.g. if it crashes) will ruin the delay timing.
- Launchbuddy doesn't update the last login attempt value in some cases, or it doesn't right away. If LB crashes, the delay timing will start from 0 and won't match the game's DDOS protection calculation.
- My login attempts always fail at the 42nd successful login, even with much longer wait timings. We need more research with larger numbers.

I also fixed a duplicate delay for active_accounts <13. Before https://github.com/TheCheatsrichter/Gw2_Launchbuddy/commit/003f4bd7e415bf7d3b7c1ab1a80f017487a44508, LB would just wait the delay silently, but now it waits the delay silently and then waits again with the blocker popup. I just removed the silent delay and left the blocker popup for all logins.