### PR TITLE
Fix for daily login reset detection

### DIFF
--- a/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
@@ -544,7 +544,7 @@ namespace Gw2_Launchbuddy.ObjectManagers
         {
             get
             {
-                DateTime resettime = DateTime.Today.ToUniversalTime();
+                DateTime resettime = DateTime.UtcNow.Date;
                 resettime = new DateTime(resettime.Year, resettime.Month, resettime.Day, 0, 0, 0);
                 return resettime < LastLogin.ToUniversalTime();
             }

--- a/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
+++ b/Gw2 Launchbuddy/ObjectManagers/AccountManager.cs
@@ -545,7 +545,6 @@ namespace Gw2_Launchbuddy.ObjectManagers
             get
             {
                 DateTime resettime = DateTime.UtcNow.Date;
-                resettime = new DateTime(resettime.Year, resettime.Month, resettime.Day, 0, 0, 0);
                 return resettime < LastLogin.ToUniversalTime();
             }
         }


### PR DESCRIPTION
Using Eastern Time as an example: 8/9/2022, 8:30PM ET is 8/10/2022, 12:30AM UTC:

The current code, DateTime.Today.ToUniversalTime(), takes the computer's date at 12AM ET, then converts it to 8/9/2022, 4:00AM UTC, then sets the time to 12AM again on the next line. This means that all logins would be incorrectly compared to 8/9/2022, 12:00AM UTC, instead of the _actual_ last reset at 8/10/2022, 12:00AM UTC.

The fixed code, DateTime.UtcNow.Date, takes the current datetime in UTC, then sets the time to 12AM. In our example, this means the code would correctly compare all logins to 8/10/2022, 12:00AM UTC.

Another example pre-reset: 8/9/2022, 7:30PM ET is 8/9/2022, 11:30PM UTC. With the fixed code, the comparison point would correctly be 8/9/2022, 12:00AM UTC.